### PR TITLE
return false added to execHTTPcheck for when connection test fails

### DIFF
--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -254,7 +254,8 @@ bool esp32FOTA::execHTTPcheck()
 
         http.end(); //Free the resources
     }
-}
+    return false;
+ }
 
 String esp32FOTA::getDeviceID()
 {


### PR DESCRIPTION
I was using AP only mode and found that the FOTA was telling me there is a new version on the web server I was using.
Obviously not true as there was no Internet connection!

Tracked down that execHTTPcheck() does not have proper return statements for all possible return paths.

Simply have added return false before the final closing brace in that function.
