### PR TITLE
Fix return type for forceUpdate

### DIFF
--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -269,12 +269,10 @@ String esp32FOTA::getDeviceID()
 }
 
 // Force a firmware update regartless on current version
-String esp32FOTA::forceUpdate(String firwmareHost, int firwmarePort, String firwmarePath)
+void esp32FOTA::forceUpdate(String firwmareHost, int firwmarePort, String firwmarePath)
 {
     _host = firwmareHost;
     _bin = firwmarePath;
     _port = firwmarePort;
     execOTA();
-
-    return true;
 }


### PR DESCRIPTION
The return type is bool but the function is declared as string.

Arduino probably doesn't complain as I have not tried this with the Arduino IDE but Visual GDB with Visual Studio and Intellisense won't build this. Returning an empty string works.