### PR TITLE
Remove unused declaration

### DIFF
--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -189,7 +189,6 @@ bool esp32FOTA::execHTTPcheck()
         useURL = checkURL;
     }
 
-    WiFiClient client;
     _port = 80;
 
     Serial.println("Getting HTTP");


### PR DESCRIPTION
Remove unused declaration `WiFiClient client` in `execHTTPcheck()` function.