### PR TITLE
stop the client connection before bailing as to not leak heap

### DIFF
--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -88,6 +88,7 @@ void esp32FOTA::execOTA()
                 if (line.indexOf("200") < 0)
                 {
                     Serial.println("Got a non 200 status code from server. Exiting OTA Update.");
+                    client.stop();
                     break;
                 }
                 gotHTTPStatus = true;


### PR DESCRIPTION
Sending in an invalid file name causes a memory leak.  The reason is client.stop() is not called before returning to the caller.  If there is not enough memory for a call with a valid firmware name, you're stuck and can't update.

Simple fix.  Proven.
