### PR TITLE
Allow the SSL port to be configurable to another value other than 443

### DIFF
--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -336,7 +336,7 @@ bool secureEsp32FOTA::prepareConnection(String destinationServer)
 {
     char *certificate = _certificate;
     clientForOta.setCACert(certificate);
-    if (clientForOta.connect(destinationServer.c_str(), 443))
+    if (clientForOta.connect(destinationServer.c_str(), _securePort))
     {
         return true;
     }

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -38,6 +38,7 @@ public:
   void executeOTA();
   String _descriptionOfFirmwareURL;
   char *_certificate;
+  unsigned int _securePort = 443;
   WiFiClientSecure clientForOta;
   String _host;
 


### PR DESCRIPTION
Hi

In my configuration at home, my Nginx runs on port 10443 and not 443 which is the default. The library is hard coded to use port 443 which causes problems when trying to connect. I've added a new variable called _securePort, which has a default value of 443, and then changed the code to use this variable rather than a hardcoded value. 

No breaking changes for anyone else, as the default value is set to 443, but now I can override it to 10443 for my Nginx. 

Hope this is ok!