### PR TITLE
Add optional SPIFFS/LITTLEFS partition support

### DIFF
--- a/fota/firmware.json
+++ b/fota/firmware.json
@@ -3,5 +3,6 @@
     "version": 2,
     "host": "192.168.0.100",
     "port": 80,
-    "bin": "/fota/esp32-fota-http-2.bin"
+    "bin": "/fota/esp32-fota-http-2.ino.bin",
+    "spiffs": "/fota/esp32-fota-http-2.spiffs.bin"
 }

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -15,11 +15,13 @@ class esp32FOTA
 {
 public:
   esp32FOTA(String firwmareType, int firwmareVersion);
-  void forceUpdate(String firwmareHost, int firwmarePort, String firwmarePath);
+  void forceUpdate(String firwmareHost, int firwmarePort, String firwmarePath, String spiffsPath="" );
   void execOTA();
+  void execOTA( int partition );
   bool execHTTPcheck();
   bool useDeviceID;
   String checkURL;
+  WiFiClient clientForOta;
 
 private:
   String getDeviceID();
@@ -27,6 +29,7 @@ private:
   int _firwmareVersion;
   String _host;
   String _bin;
+  String _spiffs;
   int _port;
 };
 
@@ -36,6 +39,7 @@ public:
   secureEsp32FOTA(String firwmareType, int firwmareVersion);
   bool execHTTPSCheck();
   void executeOTA();
+  void executeOTA( int partition );
   String _descriptionOfFirmwareURL;
   char *_certificate;
   unsigned int _securePort = 443;
@@ -50,6 +54,7 @@ private:
   int _firwmareVersion;
   String locationOfFirmware;
   String _bin;
+  String _spiffs;
   int _port;
 };
 


### PR DESCRIPTION
This patch enables flashing SPIFFS/LITTLEFS partition with the help of one optional key in the `firmware.json` file.

Created `execOTA( int partition )` and `executeOTA( int partition )` and moved the OTA logic there while using `execOTA()` and `executeOTA()` as a partition dispatcher.

Please don't merge yet, this code still needs to discussed and tested in real world situations.

