### PR TITLE
As we request HTTP/1.0, we should expect HTTP/1.0 and HTTP/1.1 as wel…

### DIFF
--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -483,7 +483,7 @@ void secureEsp32FOTA::executeOTA()
                 break; // and get the OTA started
             }
 
-            if (line.startsWith("HTTP/1.1"))
+            if (line.startsWith("HTTP/1.0") || line.startsWith("HTTP/1.1"))
             {
                 if (line.indexOf("200") < 0)
                 {


### PR DESCRIPTION
Some web servers answer HTTP/1.0 when they receive HTTP/1.0 request, and current version will refuse HTTP/1.0.
This rather trivial patch fixes that.
