### PR TITLE
Implement firmware-image signature check with RSA public/private key pair.

### DIFF
--- a/examples/HTTP/HTTP_signature_check.ino
+++ b/examples/HTTP/HTTP_signature_check.ino
@@ -1,0 +1,69 @@
+/**
+   esp32 firmware OTA
+   
+   Purpose: Perform an OTA update from a bin located on a webserver (HTTP Only)
+
+   Setup:
+   Step 1 : Set your WiFi (ssid & password)
+   Step 2 : set esp32fota()
+   
+   Upload:
+   Step 1 : Menu > Sketch > Export Compiled Library. The bin file will be saved in the sketch folder (Menu > Sketch > Show Sketch folder)
+   Step 2 : Upload it to your webserver
+   Step 3 : Update your firmware JSON file ( see firwmareupdate )
+
+*/
+#include <Arduino.h>
+#include <WiFi.h>
+
+#include <FS.h>
+#include <SPIFFS.h>
+
+#include <esp32fota.h>
+
+// Change to your WiFi credentials
+const char *ssid = "";
+const char *password = "";
+
+// esp32fota esp32fota("<Type of Firme for this device>", <this version>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1);
+
+void setup_wifi()
+{
+  delay(10);
+  Serial.print("Connecting to ");
+  Serial.println(ssid);
+
+  // Need to provide SPIFFS with rsa_key.pub inside.
+  SPIFFS.begin( true );
+  
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println("");
+  Serial.println(WiFi.localIP());
+}
+
+void setup()
+{
+  esp32FOTA.checkURL = "http://server/fota/fota.json";
+  Serial.begin(115200);
+  setup_wifi();
+}
+
+void loop()
+{
+
+  bool updatedNeeded = esp32FOTA.execHTTPcheck();
+  if (updatedNeeded)
+  {
+    esp32FOTA.execOTA();
+  }
+
+  delay(2000);
+}

--- a/fota/firmware.json
+++ b/fota/firmware.json
@@ -3,5 +3,6 @@
     "version": 2,
     "host": "192.168.0.100",
     "port": 80,
-    "bin": "/fota/esp32-fota-http-2.bin"
+    "bin": "/fota/esp32-fota-http-2.bin",
+    "check_signature": true
 }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -12,7 +12,7 @@
 #include <Update.h>
 #include "ArduinoJson.h"
 
-#include "mbedtls/rsa.h"
+#include "mbedtls/pk.h"
 #include "mbedtls/md.h"
 
 #include <WiFiClientSecure.h>

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -80,7 +80,7 @@ bool esp32FOTA::validate_sig( unsigned char *signature ) {
           mbed_md_update( &pk, buf, ENCRYPTED_BLOCK_SIZE  ) );
    mbed_md_finish( &pk, hash );
 
-   ret = mbedtls_pk_verify( &pk, MBEDTLS_MD_SHA256, (unsigned char*)hash, strlen( (const char*)hash ),
+   ret = mbedtls_pk_verify( &pk, mbedtls_md_info_from_type( MBEDTLS_MD_SHA256 ), (unsigned char*)hash, strlen( (const char*)hash ),
 			(unsigned char*)signature, strlen( (const char*) signature ) );
 
    mbedtls_md_free( &pk );

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -21,7 +21,7 @@ public:
   int getPayloadVersion();
   bool useDeviceID;
   String checkURL;
-  bool validate_sig( unsigned char* signature );
+  bool validate_sig( unsigned char *signature, uint32_t firmware_size );
 
 private:
   String getDeviceID();

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -8,7 +8,7 @@
 #ifndef esp32fota_h
 #define esp32fota_h
 
-#include "Arduino.h"
+#include <Arduino.h>
 #include <WiFiClientSecure.h>
 
 class esp32FOTA
@@ -21,6 +21,7 @@ public:
   int getPayloadVersion();
   bool useDeviceID;
   String checkURL;
+  bool validate_sig( unsigned char* signature );
 
 private:
   String getDeviceID();

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -30,6 +30,7 @@ private:
   String _host;
   String _bin;
   int _port;
+  boolean _check_sig;
 
 };
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to esp32OTA GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

Added new function to verify the signature of an OTA firmware image. This is for HTTP method only. It should not interfere with regular updates as it will only check if enabled in the firmware.json

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

I've added an example for this code, all you need is an SPIFFS-partition with your public key in it. You have to mount the FS before you can run the updater.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of esp32OTA's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.