### PR TITLE
Optionally allow HTTPS insecure

### DIFF
--- a/examples/HTTP/HTTPS_without_root_cert.ino
+++ b/examples/HTTP/HTTPS_without_root_cert.ino
@@ -1,0 +1,69 @@
+/**
+   esp32 firmware OTA
+   
+   Purpose: Perform an OTA update from a bin located on a webserver (HTTPS) without having a root cert
+
+   Setup:
+   Step 1 : Set your WiFi (ssid & password)
+   Step 2 : set esp32fota()
+   
+   Upload:
+   Step 1 : Menu > Sketch > Export Compiled Library. The bin file will be saved in the sketch folder (Menu > Sketch > Show Sketch folder)
+   Step 2 : Upload it to your webserver
+   Step 3 : Update your firmware JSON file ( see firwmareupdate )
+
+*/
+
+#include <Arduino.h>
+
+#include <WiFi.h>
+
+#include <FS.h>
+#include <SPIFFS.h>
+#include <esp32fota.h>
+
+
+// Change to your WiFi credentials
+const char *ssid = "";
+const char *password = "";
+
+// esp32fota esp32fota("<Type of Firmware for this device>", <this version>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, false, true);
+
+void setup_wifi()
+{
+  delay(10);
+  Serial.print("Connecting to ");
+  Serial.println(ssid);
+
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println("");
+  Serial.println(WiFi.localIP());
+}
+
+void setup()
+{
+  
+  esp32FOTA.checkURL = "https://server/fota/fota.json";
+  Serial.begin(115200);
+  setup_wifi();
+}
+
+void loop()
+{
+
+  bool updatedNeeded = esp32FOTA.execHTTPcheck();
+  if (updatedNeeded)
+  {
+    esp32FOTA.execOTA();
+  }
+
+  delay(2000);
+}

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -150,6 +150,7 @@ void esp32FOTA::execOTA()
     bool isValidContentType = false;
 
     HTTPClient http;
+    WiFiClientSecure client;
     //http.setConnectTimeout( 1000 );
     
     log_i("Connecting to: %s:%i%s\r\n", _host.c_str(), _port, _bin.c_str() );
@@ -175,7 +176,6 @@ void esp32FOTA::execOTA()
             }
         } else {
             // We're downloading from a secure port, but we don't want to validate the root cert.
-            WiFiClientSecure client;
             client.setInsecure();
             http.begin(client, String( "https://") + _host + ":" + String( _port ) + _bin);
         }
@@ -311,6 +311,7 @@ bool esp32FOTA::execHTTPcheck()
     if ((WiFi.status() == WL_CONNECTED)) {  //Check the current connection status
 
         HTTPClient http;
+        WiFiClientSecure client;
 
         if( useURL.substring( 0, 5 ) == "https" ) {
             if (!_allow_insecure_https) {
@@ -331,7 +332,6 @@ bool esp32FOTA::execHTTPcheck()
                 }
             } else {
                 // We're downloading from a secure port, but we don't want to validate the root cert.
-                WiFiClientSecure client;
                 client.setInsecure();
                 http.begin(client, useURL);
             }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -32,10 +32,10 @@
 
 #include <WiFiClientSecure.h>
 
-esp32FOTA::esp32FOTA(String firwmareType, int firwmareVersion, boolean validate )
+esp32FOTA::esp32FOTA(String firmwareType, int firmwareVersion, boolean validate)
 {
-    _firwmareType = firwmareType;
-    _firwmareVersion = firwmareVersion;
+    _firmwareType = firmwareType;
+    _firmwareVersion = firmwareVersion;
     _check_sig = validate;
     useDeviceID = false;
 }
@@ -357,7 +357,7 @@ bool esp32FOTA::execHTTPcheck()
 
             String fwtype(pltype);
 
-            if (plversion > _firwmareVersion && fwtype == _firwmareType) {
+            if (plversion > _firmwareVersion && fwtype == _firmwareType) {
                 http.end();
                 return true;
             }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -338,7 +338,7 @@ bool esp32FOTA::execHTTPcheck()
 
             if (err) {  //Check for errors in parsing
                 log_e("Parsing failed");
-                delay(5000);
+                http.end();
                 return false;
             }
 

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -34,8 +34,8 @@ public:
 
 private:
   String getDeviceID();
-  String _firwmareType;
-  int _firwmareVersion;
+  String _firmwareType;
+  int _firmwareVersion;
   int _payloadVersion;
   String _host;
   String _bin;

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -23,7 +23,7 @@
 class esp32FOTA
 {
 public:
-  esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false );
+  esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false, boolean allow_insecure_https = false );
   void forceUpdate(String firwmareHost, int firwmarePort, String firwmarePath, boolean validate = false );
   void execOTA();
   bool execHTTPcheck();
@@ -41,6 +41,7 @@ private:
   String _bin;
   int _port;
   boolean _check_sig;
+  boolean _allow_insecure_https;
 
 };
 


### PR DESCRIPTION
Although not ideal, there are plenty of instances where I can see a user wanting/needing to use HTTPS to transfer firmware, while not having access to the root certificate necessary to validate the HTTPS connection is in fact secure. This adds an optional flag to the esp32FOTA constructor allowing for HTTPS insecure mode to be used instead of loading the root certificate.
