### PR TITLE
Allow full URLs in firmware manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can supply http or https URLs to the checkURL. If you are using https, you n
 
 ### Hosted JSON
 
-This is hosted by a webserver and contains information about the latest firmware
+This is hosted by a webserver and contains information about the latest firmware:
 
 ```json
 {
@@ -44,6 +44,17 @@ This is hosted by a webserver and contains information about the latest firmware
     "host": "192.168.0.100",
     "port": 80,
     "bin": "/fota/esp32-fota-http-2.bin",
+    "check_signature": true
+}
+```
+
+Alternatively, a full URL path can be provided:
+
+```json
+{
+    "type": "esp32-fota-http",
+    "version": 2,
+    "url": "http://192.168.0.100/fota/esp32-fota-http-2.bin",
     "check_signature": true
 }
 ```

--- a/examples/forceUpdate/forceUpdate.ino
+++ b/examples/forceUpdate/forceUpdate.ino
@@ -1,7 +1,7 @@
 /**
    esp32 firmware OTA
 
-   Purpose: Perform an OTA update from a bin located on a webserver (HTTP Only)
+   Purpose: Perform an OTA update from a bin located on a webserver
 
    Setup:
    Step 1 : Set your WiFi (ssid & password)
@@ -21,7 +21,7 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firme for this device>", <this version>, <validate signature>);
+// esp32fota esp32fota("<Type of Firmware for this device>", <this version>, <validate signature>);
 esp32FOTA esp32FOTA("esp32-fota-http", 1, false);
 
 void setup()
@@ -53,4 +53,8 @@ void loop()
 {
   delay(2000);
   esp32FOTA.forceUpdate("192.168.0.100", 80, "/fota/esp32-fota-http-2.bin", true ); // check signature: true
+
+  // Alternatively, forceUpdate can be called with a complete URL:
+  //esp32FOTA.forceUpdate("http://192.168.0.100/fota/esp32-fota-http-2.bin", true ); // check signature: true
+
 }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -32,10 +32,10 @@
 
 #include <WiFiClientSecure.h>
 
-esp32FOTA::esp32FOTA(String firwmareType, int firwmareVersion, boolean validate )
+esp32FOTA::esp32FOTA(String firmwareType, int firmwareVersion, boolean validate)
 {
-    _firwmareType = firwmareType;
-    _firwmareVersion = firwmareVersion;
+    _firmwareType = firmwareType;
+    _firmwareVersion = firmwareVersion;
     _check_sig = validate;
     useDeviceID = false;
 }
@@ -357,7 +357,7 @@ bool esp32FOTA::execHTTPcheck()
 
             String fwtype(pltype);
 
-            if (plversion > _firwmareVersion && fwtype == _firwmareType) {
+            if (plversion > _firmwareVersion && fwtype == _firmwareType) {
                 http.end();
                 return true;
             }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -338,7 +338,7 @@ bool esp32FOTA::execHTTPcheck()
 
             if (err) {  //Check for errors in parsing
                 log_e("Parsing failed");
-                delay(5000);
+                http.end();
                 return false;
             }
 

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -24,7 +24,8 @@ class esp32FOTA
 {
 public:
   esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false );
-  void forceUpdate(String firwmareHost, int firwmarePort, String firwmarePath, boolean validate = false );
+  void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
+  void forceUpdate(String firmwareURL, boolean validate );
   void execOTA();
   bool execHTTPcheck();
   int getPayloadVersion();
@@ -37,9 +38,7 @@ private:
   String _firmwareType;
   int _firmwareVersion;
   int _payloadVersion;
-  String _host;
-  String _bin;
-  int _port;
+  String _firmwareUrl;
   boolean _check_sig;
 
 };

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -34,8 +34,8 @@ public:
 
 private:
   String getDeviceID();
-  String _firwmareType;
-  int _firwmareVersion;
+  String _firmwareType;
+  int _firmwareVersion;
   int _payloadVersion;
   String _host;
   String _bin;


### PR DESCRIPTION
This change builds on the back of changes from @thinksilicon and converts from storing `_host` `_port` and `_bin` internally we now store a full `_firmwareUrl` - and accept one in a JSON manifest. 

This maintains backwards compatibility by continuing to accept manifests that break the three fields out, as well as `forceUpdate` requests that do the same.

**Note** - This PR conflicts slightly with #73 - If you merge that first, my [firmware_url_with_insecure](https://github.com/thorrak/esp32FOTA/tree/firmware_url_with_insecure) branch can alternatively be pulled with those changes resolved.

