### PR TITLE
Add semantic versioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can supply http or https URLs to the checkURL. If you are using https, you n
 
 ### Hosted JSON
 
-This is hosted by a webserver and contains information about the latest firmware
+This is hosted by a webserver and contains information about the latest firmware:
 
 ```json
 {
@@ -44,6 +44,17 @@ This is hosted by a webserver and contains information about the latest firmware
     "host": "192.168.0.100",
     "port": 80,
     "bin": "/fota/esp32-fota-http-2.bin",
+    "check_signature": true
+}
+```
+
+Alternatively, a full URL path can be provided:
+
+```json
+{
+    "type": "esp32-fota-http",
+    "version": 2,
+    "url": "http://192.168.0.100/fota/esp32-fota-http-2.bin",
     "check_signature": true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ This is hosted by a webserver and contains information about the latest firmware
 }
 ```
 
-Alternatively, a full URL path can be provided:
+Version information can be either a single number or a semantic version string. Alternatively, a full URL path can be provided:
 
 ```json
 {
     "type": "esp32-fota-http",
-    "version": 2,
+    "version": "2.5.1",
     "url": "http://192.168.0.100/fota/esp32-fota-http-2.bin",
     "check_signature": true
 }
@@ -87,7 +87,7 @@ In this example a version 1  of 'esp32-fota-http' is in use, it would be updated
 const char *ssid = "";
 const char *password = "";
 
-esp32FOTA esp32FOTA("esp32-fota-http", 1);
+esp32FOTA esp32FOTA("esp32-fota-http", "1.0.0");
 
 void setup()
 {

--- a/README.md
+++ b/README.md
@@ -148,3 +148,8 @@ On the next update-check the ESP32 will download the `firmware.img` extract the 
 [issue 15]: https://github.com/chrisjoyce911/esp32FOTA/issues/15
 [issues 8]: https://github.com/chrisjoyce911/esp32FOTA/issues/8
 [issue 65]: https://github.com/chrisjoyce911/esp32FOTA/issues/65
+
+
+### Libraries
+
+This relies on [semver.c by h2non](https://github.com/h2non/semver.c) for semantic versioning support. semver.c is licensed under [MIT](https://github.com/h2non/semver.c/blob/master/LICENSE).

--- a/examples/HTTP/HTTPS_without_root_cert.ino
+++ b/examples/HTTP/HTTPS_without_root_cert.ino
@@ -1,0 +1,69 @@
+/**
+   esp32 firmware OTA
+   
+   Purpose: Perform an OTA update from a bin located on a webserver (HTTPS) without having a root cert
+
+   Setup:
+   Step 1 : Set your WiFi (ssid & password)
+   Step 2 : set esp32fota()
+   
+   Upload:
+   Step 1 : Menu > Sketch > Export Compiled Library. The bin file will be saved in the sketch folder (Menu > Sketch > Show Sketch folder)
+   Step 2 : Upload it to your webserver
+   Step 3 : Update your firmware JSON file ( see firwmareupdate )
+
+*/
+
+#include <Arduino.h>
+
+#include <WiFi.h>
+
+#include <FS.h>
+#include <SPIFFS.h>
+#include <esp32fota.h>
+
+
+// Change to your WiFi credentials
+const char *ssid = "";
+const char *password = "";
+
+// esp32fota esp32fota("<Type of Firmware for this device>", <this version>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, false, true);
+
+void setup_wifi()
+{
+  delay(10);
+  Serial.print("Connecting to ");
+  Serial.println(ssid);
+
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println("");
+  Serial.println(WiFi.localIP());
+}
+
+void setup()
+{
+  
+  esp32FOTA.checkURL = "https://server/fota/fota.json";
+  Serial.begin(115200);
+  setup_wifi();
+}
+
+void loop()
+{
+
+  bool updatedNeeded = esp32FOTA.execHTTPcheck();
+  if (updatedNeeded)
+  {
+    esp32FOTA.execOTA();
+  }
+
+  delay(2000);
+}

--- a/examples/forceUpdate/forceUpdate.ino
+++ b/examples/forceUpdate/forceUpdate.ino
@@ -1,7 +1,7 @@
 /**
    esp32 firmware OTA
 
-   Purpose: Perform an OTA update from a bin located on a webserver (HTTP Only)
+   Purpose: Perform an OTA update from a bin located on a webserver
 
    Setup:
    Step 1 : Set your WiFi (ssid & password)
@@ -21,7 +21,7 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firme for this device>", <this version>, <validate signature>);
+// esp32fota esp32fota("<Type of Firmware for this device>", <this version>, <validate signature>);
 esp32FOTA esp32FOTA("esp32-fota-http", 1, false);
 
 void setup()
@@ -53,4 +53,8 @@ void loop()
 {
   delay(2000);
   esp32FOTA.forceUpdate("192.168.0.100", 80, "/fota/esp32-fota-http-2.bin", true ); // check signature: true
+
+  // Alternatively, forceUpdate can be called with a complete URL:
+  //esp32FOTA.forceUpdate("http://192.168.0.100/fota/esp32-fota-http-2.bin", true ); // check signature: true
+
 }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -480,7 +480,7 @@ void esp32FOTA::forceUpdate(boolean validate )
         if (!_firmwareUrl) {
             // execHTTPcheck returns false if either the manifest is malformed or if the version isn't
             // an upgrade. If _firmwareUrl isn't set, however, we can't force an upgrade. 
-            log_e("forceUpdate called, but unable to get _firmwareUrl from manifest via execHTTPcheck.")
+            log_e("forceUpdate called, but unable to get _firmwareUrl from manifest via execHTTPcheck.");
             return;
         }
     }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -32,10 +32,10 @@
 
 #include <WiFiClientSecure.h>
 
-esp32FOTA::esp32FOTA(String firwmareType, int firwmareVersion, boolean validate )
+esp32FOTA::esp32FOTA(String firmwareType, int firmwareVersion, boolean validate)
 {
-    _firwmareType = firwmareType;
-    _firwmareVersion = firwmareVersion;
+    _firmwareType = firmwareType;
+    _firmwareVersion = firmwareVersion;
     _check_sig = validate;
     useDeviceID = false;
 }
@@ -357,7 +357,7 @@ bool esp32FOTA::execHTTPcheck()
 
             String fwtype(pltype);
 
-            if (plversion > _firwmareVersion && fwtype == _firwmareType) {
+            if (plversion > _firmwareVersion && fwtype == _firmwareType) {
                 http.end();
                 return true;
             }

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -338,7 +338,7 @@ bool esp32FOTA::execHTTPcheck()
 
             if (err) {  //Check for errors in parsing
                 log_e("Parsing failed");
-                delay(5000);
+                http.end();
                 return false;
             }
 

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -433,8 +433,7 @@ bool esp32FOTA::execHTTPcheck()
                 http.end();
                 return true;
             }
-        }
-        else {
+        } else {
             log_e("Error on HTTP request");
         }
         http.end();  //Free the resources
@@ -474,6 +473,20 @@ void esp32FOTA::forceUpdate(String firmwareHost, uint16_t firmwarePort, String f
     forceUpdate(firmwareURL, validate);
 }
 
+void esp32FOTA::forceUpdate(boolean validate )
+{
+    // Forces an update from a manifest, ignoring the version check
+    if(!execHTTPcheck()) {
+        if (!_firmwareUrl) {
+            // execHTTPcheck returns false if either the manifest is malformed or if the version isn't
+            // an upgrade. If _firmwareUrl isn't set, however, we can't force an upgrade. 
+            log_e("forceUpdate called, but unable to get _firmwareUrl from manifest via execHTTPcheck.")
+            return;
+        }
+    }
+    _check_sig = validate;
+    execOTA();
+}
 
 
 /**

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -24,7 +24,8 @@ class esp32FOTA
 {
 public:
   esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false );
-  void forceUpdate(String firwmareHost, int firwmarePort, String firwmarePath, boolean validate = false );
+  void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
+  void forceUpdate(String firmwareURL, boolean validate );
   void execOTA();
   bool execHTTPcheck();
   int getPayloadVersion();
@@ -37,9 +38,7 @@ private:
   String _firmwareType;
   int _firmwareVersion;
   int _payloadVersion;
-  String _host;
-  String _bin;
-  int _port;
+  String _firmwareUrl;
   boolean _check_sig;
 
 };

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -23,7 +23,7 @@
 class esp32FOTA
 {
 public:
-  esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false );
+  esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false, boolean allow_insecure_https = false );
   void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
   void forceUpdate(String firmwareURL, boolean validate );
   void execOTA();
@@ -40,6 +40,7 @@ private:
   int _payloadVersion;
   String _firmwareUrl;
   boolean _check_sig;
+  boolean _allow_insecure_https;
 
 };
 

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -19,16 +19,19 @@
 #define esp32fota_h
 
 #include <Arduino.h>
+#include "semver/semver.h"
 
 class esp32FOTA
 {
 public:
   esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false, boolean allow_insecure_https = false );
+  esp32FOTA(String firwmareType, String firmwareSemanticVersion, boolean validate = false, boolean allow_insecure_https = false );
+  ~esp32FOTA();
   void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
   void forceUpdate(String firmwareURL, boolean validate );
   void execOTA();
   bool execHTTPcheck();
-  int getPayloadVersion();
+  // int getPayloadVersion();
   bool useDeviceID;
   String checkURL;
   bool validate_sig( unsigned char *signature, uint32_t firmware_size );
@@ -36,8 +39,8 @@ public:
 private:
   String getDeviceID();
   String _firmwareType;
-  int _firmwareVersion;
-  int _payloadVersion;
+  semver_t _firmwareVersion;
+  semver_t _payloadVersion;
   String _firmwareUrl;
   boolean _check_sig;
   boolean _allow_insecure_https;

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -31,7 +31,8 @@ public:
   void forceUpdate(String firmwareURL, boolean validate );
   void execOTA();
   bool execHTTPcheck();
-  // int getPayloadVersion();
+  int getPayloadVersion();
+  void getPayloadVersion(char * version_string);
   bool useDeviceID;
   String checkURL;
   bool validate_sig( unsigned char *signature, uint32_t firmware_size );
@@ -39,8 +40,8 @@ public:
 private:
   String getDeviceID();
   String _firmwareType;
-  semver_t _firmwareVersion;
-  semver_t _payloadVersion;
+  semver_t _firmwareVersion = {0};
+  semver_t _payloadVersion = {0};
   String _firmwareUrl;
   boolean _check_sig;
   boolean _allow_insecure_https;

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -29,6 +29,7 @@ public:
   ~esp32FOTA();
   void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
   void forceUpdate(String firmwareURL, boolean validate );
+  void forceUpdate(boolean validate );
   void execOTA();
   bool execHTTPcheck();
   int getPayloadVersion();

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -34,8 +34,8 @@ public:
 
 private:
   String getDeviceID();
-  String _firwmareType;
-  int _firwmareVersion;
+  String _firmwareType;
+  int _firmwareVersion;
   int _payloadVersion;
   String _host;
   String _bin;

--- a/src/semver/README.md
+++ b/src/semver/README.md
@@ -1,0 +1,233 @@
+# semver.c [![Build Status](https://travis-ci.org/h2non/semver.c.png)](https://travis-ci.org/h2non/semver.c) [![GitHub release](https://img.shields.io/github/tag/h2non/semver.c.svg)](https://github.com/h2non/semver.c/releases)
+
+[Semantic version](http://semver.org) v2.0 parser and render written in [ANSI C](https://en.wikipedia.org/wiki/ANSI_C) with zero dependencies.
+
+## Features
+
+- [x] Standard compliant (otherwise, open an issue)
+- [x] Version metadata parsing
+- [x] Version prerelease parsing
+- [x] Version comparison helpers
+- [x] Supports comparison operators
+- [x] Version render
+- [x] Version bump
+- [x] Version sanitizer
+- [x] 100% test coverage
+- [x] No regexp (ANSI C doesn't support it)
+- [x] Numeric conversion for sorting/filtering
+
+## Versions
+
+- [v0](https://github.com/h2non/semver.c/tree/89e66f36544e0250def32640b84b7e15c8585da4) - Legacy version. Beta. Not maintained anymore.
+- [v1](https://github.com/h2non/semver.c) - Current stable version.
+
+## Usage
+
+Basic comparison:
+```c
+#include <stdio.h>
+#include <semver.h>
+
+char current[] = "1.5.10";
+char compare[] = "2.3.0";
+
+int
+main(int argc, char *argv[]) {
+    semver_t current_version = {};
+    semver_t compare_version = {};
+
+    if (semver_parse(current, &current_version)
+      || semver_parse(compare, &compare_version)) {
+      fprintf(stderr,"Invalid semver string\n");
+      return -1;
+    }
+
+    int resolution = semver_compare(compare_version, current_version);
+
+    if (resolution == 0) {
+      printf("Versions %s is equal to: %s\n", compare, current);
+    }
+    else if (resolution == -1) {
+      printf("Version %s is lower than: %s\n", compare, current);
+    }
+    else {
+      printf("Version %s is higher than: %s\n", compare, current);
+    }
+
+    // Free allocated memory when we're done
+    semver_free(&current_version);
+    semver_free(&compare_version);
+    return 0;
+}
+```
+
+Satisfies version:
+
+```c
+#include <stdio.h>
+#include <semver.h>
+
+semver_t current = {};
+semver_t compare = {};
+
+int
+main(int argc, char *argv[]) {
+    semver_parse("1.3.10", &current);
+    semver_parse("1.5.2", &compare);
+
+    // Use caret operator for the comparison
+    char operator[] = "^";
+
+    if (semver_satisfies(current, compare, operator)) {
+      printf("Version %s can be satisfied by %s", "1.3.10", "1.5.2");
+    }
+
+    // Free allocated memory when we're done
+    semver_free(&current);
+    semver_free(&compare);
+    return 0;
+}
+```
+
+## Installation
+
+Clone this repository:
+
+```bash
+$ git clone https://github.com/h2non/semver.c
+```
+
+Or install with [clib](https://github.com/clibs/clib):
+
+```bash
+$ clib install h2non/semver.c
+```
+
+## API
+
+#### struct semver_t { int major, int minor, int patch, char * prerelease, char * metadata }
+
+semver base struct.
+
+#### semver_parse(const char *str, semver_t *ver) => int
+
+Parses a string as semver expression.
+
+**Returns**:
+
+- `-1` - In case of invalid semver or parsing error.
+- `0` - All was fine!
+
+#### semver_compare(semver_t a, semver_t b) => int
+
+Compare versions `a` with `b`.
+
+Returns:
+- `-1` in case of lower version.
+- `0` in case of equal versions.
+- `1` in case of higher version.
+
+#### semver_satisfies(semver_t a, semver_t b, char *operator) => int
+
+Checks if both versions can be satisfied
+based on the given comparison operator.
+
+**Allowed operators**:
+
+- `=`  - Equality
+- `>=` - Higher or equal to
+- `<=` - Lower or equal to
+- `<`  - Lower than
+- `>`  - Higher than
+- `^`  - Caret operator comparison ([more info](https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4))
+- `~`  - Tilde operator comparison ([more info](https://docs.npmjs.com/misc/semver#tilde-ranges-1-2-3-1-2-1))
+
+**Returns**:
+
+- `1` - Can be satisfied
+- `0` - Cannot be satisfied
+
+#### semver_satisfies_caret(semver_t a, semver_t b) => int
+
+Checks if version `x` can be satisfied by `y`
+performing a comparison with caret operator.
+
+See: https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4
+
+**Returns**:
+
+- `1` - Can be satisfied
+- `0` - Cannot be satisfied
+
+#### semver_satisfies_patch(semver_t a, semver_t b) => int
+
+Checks if version `x` can be satisfied by `y`
+performing a comparison with tilde operator.
+
+See: https://docs.npmjs.com/misc/semver#tilde-ranges-1-2-3-1-2-1
+
+**Returns**:
+
+- `1` - Can be satisfied
+- `0` - Cannot be satisfied
+
+
+#### semver_eq(semver_t a, semver_t b) => int
+
+Equality comparison.
+
+#### semver_ne(semver_t a, semver_t b) => int
+
+Non equal comparison.
+
+#### semver_gt(semver_t a, semver_t b) => int
+
+Greater than comparison.
+
+#### semver_lt(semver_t a, semver_t b) => int
+
+Lower than comparison.
+
+#### semver_gte(semver_t a, semver_t b) => int
+
+Greater than or equal comparison.
+
+#### semver_lte(semver_t a, semver_t b) => int
+
+Lower than or equal comparison.
+
+#### semver_render(semver_t *v, char *dest) => void
+
+Render as string.
+
+#### semver_numeric(semver_t *v) => int
+
+Render as numeric value. Useful for ordering and filtering.
+
+#### semver_bump(semver_t *a) => void
+
+Bump major version.
+
+#### semver_bump_minor(semver_t *a) => void
+
+Bump minor version.
+
+#### semver_bump_patch(semver_t *a) => void
+
+Bump patch version.
+
+#### semver_free(semver_t *a) => void
+
+Helper to free allocated memory from heap.
+
+#### semver_is_valid(char *str) => int
+
+Checks if the given string is a valid semver expression.
+
+#### semver_clean(char *str) => int
+
+Removes invalid semver characters in a given string.
+
+## License
+
+MIT - Tomas Aparicio

--- a/src/semver/semver.c
+++ b/src/semver/semver.c
@@ -1,0 +1,638 @@
+/*
+ * semver.c
+ *
+ * Copyright (c) 2015-2017 Tomas Aparicio
+ * MIT licensed
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "semver.h"
+
+#define SLICE_SIZE   50
+#define DELIMITER    "."
+#define PR_DELIMITER "-"
+#define MT_DELIMITER "+"
+#define NUMBERS      "0123456789"
+#define ALPHA        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#define DELIMITERS   DELIMITER PR_DELIMITER MT_DELIMITER
+#define VALID_CHARS  NUMBERS ALPHA DELIMITERS
+
+static const size_t MAX_SIZE     = sizeof(char) * 255;
+static const int MAX_SAFE_INT = (unsigned int) -1 >> 1;
+
+/**
+ * Define comparison operators, storing the
+ * ASCII code per each symbol in hexadecimal notation.
+ */
+
+enum operators {
+  SYMBOL_GT = 0x3e,
+  SYMBOL_LT = 0x3c,
+  SYMBOL_EQ = 0x3d,
+  SYMBOL_TF = 0x7e,
+  SYMBOL_CF = 0x5e
+};
+
+/**
+ * Private helpers
+ */
+
+/*
+ * Remove [begin:len-begin] from str by moving len data from begin+len to begin.
+ * If len is negative cut out to the end of the string.
+ */
+static int
+strcut (char *str, int begin, int len) {
+  size_t l;
+  l = strlen(str);
+
+  if((int)l < 0 || (int)l > MAX_SAFE_INT) return -1;
+
+  if (len < 0) len = l - begin + 1;
+  if (begin + len > (int)l) len = l - begin;
+  memmove(str + begin, str + begin + len, l - len + 1 - begin);
+
+  return len;
+}
+
+static int
+contains (const char c, const char *matrix, size_t len) {
+  size_t x;
+  for (x = 0; x < len; x++)
+    if ((char) matrix[x] == c) return 1;
+  return 0;
+}
+
+static int
+has_valid_chars (const char *str, const char *matrix) {
+  size_t i, len, mlen;
+  len = strlen(str);
+  mlen = strlen(matrix);
+
+  for (i = 0; i < len; i++)
+    if (contains(str[i], matrix, mlen) == 0)
+      return 0;
+
+  return 1;
+}
+
+static int
+binary_comparison (int x, int y) {
+  if (x == y) return 0;
+  if (x > y) return 1;
+  return -1;
+}
+
+static int
+parse_int (const char *s) {
+  int valid, num;
+  valid = has_valid_chars(s, NUMBERS);
+  if (valid == 0) return -1;
+
+  num = strtol(s, NULL, 10);
+  if (num > MAX_SAFE_INT) return -1;
+
+  return num;
+}
+
+/*
+ * Return a string allocated on the heap with the content from sep to end and
+ * terminate buf at sep.
+ */
+static char *
+parse_slice (char *buf, char sep) {
+  char *pr, *part;
+  int plen;
+
+  /* Find separator in buf */
+  pr = strchr(buf, sep);
+  if (pr == NULL) return NULL;
+  /* Length from separator to end of buf */
+  plen = strlen(pr);
+
+  /* Copy from buf into new string */
+  part = (char*)calloc(plen + 1, sizeof(*part));
+  if (part == NULL) return NULL;
+  memcpy(part, pr + 1, plen);
+  /* Null terminate new string */
+  part[plen] = '\0';
+
+  /* Terminate buf where separator was */
+  *pr = '\0';
+
+  return part;
+}
+
+/**
+ * Parses a string as semver expression.
+ *
+ * Returns:
+ *
+ * `0` - Parsed successfully
+ * `-1` - In case of error
+ */
+
+int
+semver_parse (const char *str, semver_t *ver) {
+  int valid, res;
+  size_t len;
+  char *buf;
+  valid = semver_is_valid(str);
+  if (!valid) return -1;
+
+  len = strlen(str);
+  buf = (char*)calloc(len + 1, sizeof(*buf));
+  if (buf == NULL) return -1;
+  strcpy(buf, str);
+
+  ver->metadata = parse_slice(buf, MT_DELIMITER[0]);
+  ver->prerelease = parse_slice(buf, PR_DELIMITER[0]);
+
+  res = semver_parse_version(buf, ver);
+  free(buf);
+#if DEBUG > 0
+  printf("[debug] semver.c %s = %d.%d.%d, %s %s\n", str, ver->major, ver->minor, ver->patch, ver->prerelease, ver->metadata);
+#endif
+  return res;
+}
+
+/**
+ * Parses a given string as semver expression.
+ *
+ * Returns:
+ *
+ * `0` - Parsed successfully
+ * `-1` - Parse error or invalid
+ */
+
+int
+semver_parse_version (const char *str, semver_t *ver) {
+  size_t len;
+  int index, value;
+  char *slice, *next, *endptr;
+  slice = (char *) str;
+  index = 0;
+
+  while (slice != NULL && index++ < 4) {
+    next = strchr(slice, DELIMITER[0]);
+    if (next == NULL)
+      len = strlen(slice);
+    else
+      len = next - slice;
+    if (len > SLICE_SIZE) return -1;
+
+    /* Cast to integer and store */
+    value = strtol(slice, &endptr, 10);
+    if (endptr != next && *endptr != '\0') return -1;
+
+    switch (index) {
+      case 1: ver->major = value; break;
+      case 2: ver->minor = value; break;
+      case 3: ver->patch = value; break;
+    }
+
+    /* Continue with the next slice */
+    if (next == NULL)
+      slice = NULL;
+    else
+      slice = next + 1;
+  }
+
+  return 0;
+}
+
+static int
+compare_prerelease (char *x, char *y) {
+  char *lastx, *lasty, *xptr, *yptr, *endptr;
+  int xlen, ylen, xisnum, yisnum, xnum, ynum;
+  int xn, yn, min, res;
+  if (x == NULL && y == NULL) return 0;
+  if (y == NULL && x) return -1;
+  if (x == NULL && y) return 1;
+
+  lastx = x;
+  lasty = y;
+  xlen = strlen(x);
+  ylen = strlen(y);
+
+  while (1) {
+    if ((xptr = strchr(lastx, DELIMITER[0])) == NULL)
+      xptr = x + xlen;
+    if ((yptr = strchr(lasty, DELIMITER[0])) == NULL)
+      yptr = y + ylen;
+
+    xnum = strtol(lastx, &endptr, 10);
+    xisnum = endptr == xptr ? 1 : 0;
+    ynum = strtol(lasty, &endptr, 10);
+    yisnum = endptr == yptr ? 1 : 0;
+
+    if (xisnum && !yisnum) return -1;
+    if (!xisnum && yisnum) return 1;
+
+    if (xisnum && yisnum) {
+      /* Numerical comparison */
+      if (xnum != ynum) return xnum < ynum ? -1 : 1;
+    } else {
+      /* String comparison */
+      xn = xptr - lastx;
+      yn = yptr - lasty;
+      min = xn < yn ? xn : yn;
+      if ((res = strncmp(lastx, lasty, min))) return res < 0 ? -1 : 1;
+      if (xn != yn) return xn < yn ? -1 : 1;
+    }
+
+    lastx = xptr + 1;
+    lasty = yptr + 1;
+    if (lastx == x + xlen + 1 && lasty == y + ylen + 1) break;
+    if (lastx == x + xlen + 1) return -1;
+    if (lasty == y + ylen + 1) return 1;
+  }
+
+  return 0;
+}
+
+int
+semver_compare_prerelease (semver_t x, semver_t y) {
+  return compare_prerelease(x.prerelease, y.prerelease);
+}
+
+/**
+ * Performs a major, minor and patch binary comparison (x, y).
+ * This function is mostly used internally
+ *
+ * Returns:
+ *
+ * `0` - If versiona are equal
+ * `1` - If x is higher than y
+ * `-1` - If x is lower than y
+ */
+
+int
+semver_compare_version (semver_t x, semver_t y) {
+  int res;
+
+  if ((res = binary_comparison(x.major, y.major)) == 0) {
+    if ((res = binary_comparison(x.minor, y.minor)) == 0) {
+      return binary_comparison(x.patch, y.patch);
+    }
+  }
+
+  return res;
+}
+
+/**
+ * Compare two semantic versions (x, y).
+ *
+ * Returns:
+ * - `1` if x is higher than y
+ * - `0` if x is equal to y
+ * - `-1` if x is lower than y
+ */
+
+int
+semver_compare (semver_t x, semver_t y) {
+  int res;
+
+  if ((res = semver_compare_version(x, y)) == 0) {
+    return semver_compare_prerelease(x, y);
+  }
+
+  return res;
+}
+
+/**
+ * Performs a `greater than` comparison
+ */
+
+int
+semver_gt (semver_t x, semver_t y) {
+  return semver_compare(x, y) == 1;
+}
+
+/**
+ * Performs a `lower than` comparison
+ */
+
+int
+semver_lt (semver_t x, semver_t y) {
+  return semver_compare(x, y) == -1;
+}
+
+/**
+ * Performs a `equality` comparison
+ */
+
+int
+semver_eq (semver_t x, semver_t y) {
+  return semver_compare(x, y) == 0;
+}
+
+/**
+ * Performs a `non equal to` comparison
+ */
+
+int
+semver_neq (semver_t x, semver_t y) {
+  return semver_compare(x, y) != 0;
+}
+
+/**
+ * Performs a `greater than or equal` comparison
+ */
+
+int
+semver_gte (semver_t x, semver_t y) {
+  return semver_compare(x, y) >= 0;
+}
+
+/**
+ * Performs a `lower than or equal` comparison
+ */
+
+int
+semver_lte (semver_t x, semver_t y) {
+  return semver_compare(x, y) <= 0;
+}
+
+/**
+ * Checks if version `x` can be satisfied by `y`
+ * performing a comparison with caret operator.
+ *
+ * See: https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4
+ *
+ * Returns:
+ *
+ * `1` - Can be satisfied
+ * `0` - Cannot be satisfied
+ */
+
+int
+semver_satisfies_caret (semver_t x, semver_t y) {
+  /* Major versions must always match. */
+  if (x.major == y.major) {
+    /* If major version is 0, minor versions must match */
+    if (x.major == 0) {
+        /* If minor version is 0, patch must match */
+        if (x.minor == 0){
+          return (x.minor == y.minor) && (x.patch == y.patch);
+        }
+        /* If minor version is not 0, patch must be >= */
+        else if (x.minor == y.minor){
+          return x.patch >= y.patch;
+        }
+        else{
+          return 0;
+        }
+      }
+    else if (x.minor > y.minor){
+      return 1;
+    }
+    else if (x.minor == y.minor)
+    {
+      return x.patch >= y.patch;
+    }
+    else {
+      return 0;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Checks if version `x` can be satisfied by `y`
+ * performing a comparison with tilde operator.
+ *
+ * See: https://docs.npmjs.com/misc/semver#tilde-ranges-1-2-3-1-2-1
+ *
+ * Returns:
+ *
+ * `1` - Can be satisfied
+ * `0` - Cannot be satisfied
+ */
+
+int
+semver_satisfies_patch (semver_t x, semver_t y) {
+  return x.major == y.major
+      && x.minor == y.minor;
+}
+
+/**
+ * Checks if both versions can be satisfied
+ * based on the given comparison operator.
+ *
+ * Allowed operators:
+ *
+ * - `=`  - Equality
+ * - `>=` - Higher or equal to
+ * - `<=` - Lower or equal to
+ * - `<`  - Lower than
+ * - `>`  - Higher than
+ * - `^`  - Caret comparison (see https://docs.npmjs.com/misc/semver#caret-ranges-1-2-3-0-2-5-0-0-4)
+ * - `~`  - Tilde comparison (see https://docs.npmjs.com/misc/semver#tilde-ranges-1-2-3-1-2-1)
+ *
+ * Returns:
+ *
+ * `1` - Can be satisfied
+ * `0` - Cannot be satisfied
+ */
+
+int
+semver_satisfies (semver_t x, semver_t y, const char *op) {
+  int first, second;
+  /* Extract the comparison operator */
+  first = op[0];
+  second = op[1];
+
+  /* Caret operator */
+  if (first == SYMBOL_CF)
+    return semver_satisfies_caret(x, y);
+
+  /* Tilde operator */
+  if (first == SYMBOL_TF)
+    return semver_satisfies_patch(x, y);
+
+  /* Strict equality */
+  if (first == SYMBOL_EQ)
+    return semver_eq(x, y);
+
+  /* Greater than or equal comparison */
+  if (first == SYMBOL_GT) {
+    if (second == SYMBOL_EQ) {
+      return semver_gte(x, y);
+    }
+    return semver_gt(x, y);
+  }
+
+  /* Lower than or equal comparison */
+  if (first == SYMBOL_LT) {
+    if (second == SYMBOL_EQ) {
+      return semver_lte(x, y);
+    }
+    return semver_lt(x, y);
+  }
+
+  return 0;
+}
+
+/**
+ * Free heep allocated memory of a given semver.
+ * This is just a convenient function that you
+ * should call when you're done.
+ */
+
+void
+semver_free (semver_t *x) {
+  if (x->metadata) {
+    free(x->metadata);
+    x->metadata = NULL;
+  }
+  if (x->prerelease) {
+    free(x->prerelease);
+    x->prerelease = NULL;
+  }
+}
+
+/**
+ * Renders
+ */
+
+static void
+concat_num (char * str, int x, char * sep) {
+  char buf[SLICE_SIZE] = {0};
+  if (sep == NULL) sprintf(buf, "%d", x);
+  else sprintf(buf, "%s%d", sep, x);
+  strcat(str, buf);
+}
+
+static void
+concat_char (char * str, char * x, char * sep) {
+  char buf[SLICE_SIZE] = {0};
+  sprintf(buf, "%s%s", sep, x);
+  strcat(str, buf);
+}
+
+/**
+ * Render a given semver as string
+ */
+
+void
+semver_render (semver_t *x, char *dest) {
+  concat_num(dest, x->major, NULL);
+  concat_num(dest, x->minor, DELIMITER);
+  concat_num(dest, x->patch, DELIMITER);
+  if (x->prerelease) concat_char(dest, x->prerelease, PR_DELIMITER);
+  if (x->metadata) concat_char(dest, x->metadata, MT_DELIMITER);
+}
+
+/**
+ * Version bump helpers
+ */
+
+void
+semver_bump (semver_t *x) {
+  x->major++;
+}
+
+void
+semver_bump_minor (semver_t *x) {
+  x->minor++;
+}
+
+void
+semver_bump_patch (semver_t *x) {
+  x->patch++;
+}
+
+/**
+ * Helpers
+ */
+
+static int
+has_valid_length (const char *s) {
+  return strlen(s) <= MAX_SIZE;
+}
+
+/**
+ * Checks if a given semver string is valid
+ *
+ * Returns:
+ *
+ * `1` - Valid expression
+ * `0` - Invalid
+ */
+
+int
+semver_is_valid (const char *s) {
+  return has_valid_length(s)
+      && has_valid_chars(s, VALID_CHARS);
+}
+
+/**
+ * Removes non-valid characters in the given string.
+ *
+ * Returns:
+ *
+ * `0`  - Valid
+ * `-1` - Invalid input
+ */
+
+int
+semver_clean (char *s) {
+  size_t i, len, mlen;
+  int res;
+  if (has_valid_length(s) == 0) return -1;
+
+  len = strlen(s);
+  mlen = strlen(VALID_CHARS);
+
+  for (i = 0; i < len; i++) {
+    if (contains(s[i], VALID_CHARS, mlen) == 0) {
+      res = strcut(s, i, 1);
+      if(res == -1) return -1;
+      --len; --i;
+    }
+  }
+
+  return 0;
+}
+
+static int
+char_to_int (const char * str) {
+  int buf;
+  size_t i,len, mlen;
+  buf = 0;
+  len = strlen(str);
+  mlen = strlen(VALID_CHARS);
+
+  for (i = 0; i < len; i++)
+    if (contains(str[i], VALID_CHARS, mlen))
+      buf += (int) str[i];
+
+  return buf;
+}
+
+/**
+ * Render a given semver as numeric value.
+ * Useful for ordering and filtering.
+ */
+
+int
+semver_numeric (semver_t *x) {
+  int num;
+  char buf[SLICE_SIZE * 3];
+  memset(&buf, 0, SLICE_SIZE * 3);
+
+  if (x->major) concat_num(buf, x->major, NULL);
+  if (x->major || x->minor) concat_num(buf, x->minor, NULL);
+  if (x->major || x->minor || x->patch) concat_num(buf, x->patch, NULL);
+
+  num = parse_int(buf);
+  if(num == -1) return -1;
+
+  if (x->prerelease) num += char_to_int(x->prerelease);
+  if (x->metadata) num += char_to_int(x->metadata);
+
+  return num;
+}

--- a/src/semver/semver.h
+++ b/src/semver/semver.h
@@ -1,0 +1,105 @@
+/*
+ * semver.h
+ *
+ * Copyright (c) 2015-2017 Tomas Aparicio
+ * MIT licensed
+ */
+
+#ifndef __SEMVER_H
+#define __SEMVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef SEMVER_VERSION
+#define SEMVER_VERSION "0.2.0"
+#endif
+
+/**
+ * semver_t struct
+ */
+
+typedef struct semver_version_s {
+  int major;
+  int minor;
+  int patch;
+  char * metadata;
+  char * prerelease;
+} semver_t;
+
+/**
+ * Set prototypes
+ */
+
+int
+semver_satisfies (semver_t x, semver_t y, const char *op);
+
+int
+semver_satisfies_caret (semver_t x, semver_t y);
+
+int
+semver_satisfies_patch (semver_t x, semver_t y);
+
+int
+semver_compare (semver_t x, semver_t y);
+
+int
+semver_compare_version (semver_t x, semver_t y);
+
+int
+semver_compare_prerelease (semver_t x, semver_t y);
+
+int
+semver_gt (semver_t x, semver_t y);
+
+int
+semver_gte (semver_t x, semver_t y);
+
+int
+semver_lt (semver_t x, semver_t y);
+
+int
+semver_lte (semver_t x, semver_t y);
+
+int
+semver_eq (semver_t x, semver_t y);
+
+int
+semver_neq (semver_t x, semver_t y);
+
+int
+semver_parse (const char *str, semver_t *ver);
+
+int
+semver_parse_version (const char *str, semver_t *ver);
+
+void
+semver_render (semver_t *x, char *dest);
+
+int
+semver_numeric (semver_t *x);
+
+void
+semver_bump (semver_t *x);
+
+void
+semver_bump_minor (semver_t *x);
+
+void
+semver_bump_patch (semver_t *x);
+
+void
+semver_free (semver_t *x);
+
+int
+semver_is_valid (const char *s);
+
+int
+semver_clean (char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR adds support for semantic versioning, relying on [h2non's semver.c library](https://github.com/h2non/semver.c) to actually parse/compare semantic version strings. His library is MIT licensed. As the library is not part of the platformio library registry, I've manually included the library's code in the `src/semver/` directory -- If anyone has a better way to do this, I'd love to hear it!

I've submitted a handful of PRs as I've been tweaking things - this PR is based on a branch that assumes that those PRs have been merged. That said, there is nothing specific to semantic versioning support that requires any of those changes. 

This PR should close #59 