### PR TITLE
Allow multiple firmware types in a single JSON manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ This is hosted by a webserver and contains information about the latest firmware
     "host": "192.168.0.100",
     "port": 80,
     "bin": "/fota/esp32-fota-http-2.bin",
-    "check_signature": true
 }
 ```
 
@@ -56,7 +55,6 @@ Version information can be either a single number or a semantic version string. 
     "type": "esp32-fota-http",
     "version": "2.5.1",
     "url": "http://192.168.0.100/fota/esp32-fota-http-2.bin",
-    "check_signature": true
 }
 ```
 
@@ -68,7 +66,6 @@ A single JSON file can provide information on multiple firmware types by combini
       "type":"esp32-fota-http",
       "version":"0.0.2",
       "url":"http://192.168.0.100/fota/esp32-fota-http-2.bin",
-      "check_signature":true
    },
    {
       "type":"esp32-other-hardware",

--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ Version information can be either a single number or a semantic version string. 
 }
 ```
 
+A single JSON file can provide information on multiple firmware types by combining them together into an array. When this is loaded, the firmware manifest with a type matching the one passed to the esp32FOTA constructor will be selected:
+
+```json
+[
+   {
+      "type":"esp32-fota-http",
+      "version":"0.0.2",
+      "url":"http://192.168.0.100/fota/esp32-fota-http-2.bin",
+      "check_signature":true
+   },
+   {
+      "type":"esp32-other-hardware",
+      "version":"0.0.3",
+      "url":"http://192.168.0.100/fota/esp32-other-hardware.bin"
+   }
+]
+```
+
+
 #### Firmware types
 
 Types are used to compare with the current loaded firmware, this is used to make sure that when loaded, the device will still do the intended job.

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -19,6 +19,7 @@
 #define esp32fota_h
 
 #include <Arduino.h>
+#include <ArduinoJson.h>
 #include "semver/semver.h"
 
 class esp32FOTA
@@ -46,6 +47,7 @@ private:
   String _firmwareUrl;
   boolean _check_sig;
   boolean _allow_insecure_https;
+  bool checkJSONManifest(JsonVariant JSONDocument);
 
 };
 


### PR DESCRIPTION
This change allows a single JSON manifest file to contain multiple firmware types, combining individual manifest files into a single JSON array. Example:

```json
[
   {
      "type":"esp32-fota-http",
      "version":"0.0.2",
      "url":"http://192.168.0.100/fota/esp32-fota-http-2.bin",
      "check_signature":true
   },
   {
      "type":"esp32-other-hardware",
      "version":"0.0.3",
      "url":"http://192.168.0.100/fota/esp32-other-hardware.bin"
   }
]
```

When `esp32FOTA::execHTTPcheck()` encounters a manifest such as the above it will loop through each of the individual dicts in the array until it finds the first with a matching firmware type, which it will then proceed to load. If it doesn't find a matching firmware type, `esp32FOTA::execHTTPcheck()` will return false. 

This change maintains support for the existing single-manifest format.

In order to facilitate the above, I have also cleaned up `esp32FOTA::execHTTPcheck()` and moved some the "loading" of the data from the JSON manifest into its own function. I've broken these changes out into separate commits to make them easier to follow. 