### PR TITLE
Pass in filesystem rather than requiring SPIFFS (Fixes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,12 @@ In this example a version 1  of 'esp32-fota-http' is in use, it would be updated
 ```cpp
 #include <esp32fota.h>
 #include <WiFi.h>
+#include <SPIFFS.h>
 
 const char *ssid = "";
 const char *password = "";
 
-esp32FOTA esp32FOTA("esp32-fota-http", "1.0.0");
+esp32FOTA esp32FOTA("esp32-fota-http", "1.0.0", SPIFFS);
 
 void setup()
 {

--- a/examples/HTTP/HTTP.ino
+++ b/examples/HTTP/HTTP.ino
@@ -23,8 +23,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false, false);
 
 void setup_wifi()
 {

--- a/examples/HTTP/HTTP.ino
+++ b/examples/HTTP/HTTP.ino
@@ -14,15 +14,17 @@
 
 */
 
+#include <SPIFFS.h>
 #include <esp32fota.h>
 #include <WiFi.h>
+#include <SPIFFS.h>
 
 // Change to your WiFi credentials
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firme for this device>", <this version>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
 
 void setup_wifi()
 {

--- a/examples/HTTP/HTTPS.ino
+++ b/examples/HTTP/HTTPS.ino
@@ -28,8 +28,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false, false);
 
 void setup_wifi()
 {

--- a/examples/HTTP/HTTPS.ino
+++ b/examples/HTTP/HTTPS.ino
@@ -28,8 +28,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firme for this device>", <this version>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
 
 void setup_wifi()
 {

--- a/examples/HTTP/HTTPS_without_root_cert.ino
+++ b/examples/HTTP/HTTPS_without_root_cert.ino
@@ -27,8 +27,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firmware for this device>", <this version>, <validate signature>, <allow insecure https>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, false, true);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false, true);
 
 void setup_wifi()
 {

--- a/examples/HTTP/HTTP_signature_check.ino
+++ b/examples/HTTP/HTTP_signature_check.ino
@@ -25,8 +25,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, true);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, true, false);
 
 void setup_wifi()
 {

--- a/examples/HTTP/HTTP_signature_check.ino
+++ b/examples/HTTP/HTTP_signature_check.ino
@@ -25,8 +25,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firme for this device>", <this version>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, true);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, true);
 
 void setup_wifi()
 {

--- a/examples/forceUpdate/forceUpdate.ino
+++ b/examples/forceUpdate/forceUpdate.ino
@@ -22,8 +22,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false, false);
 
 void setup()
 {

--- a/examples/forceUpdate/forceUpdate.ino
+++ b/examples/forceUpdate/forceUpdate.ino
@@ -16,13 +16,14 @@
 
 #include <esp32fota.h>
 #include <WiFi.h>
+#include <SPIFFS.h>
 
 // Change to your WiFi credentials
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firmware for this device>", <this version>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
 
 void setup()
 {

--- a/examples/withDeviceID/withDeviceID.ino
+++ b/examples/withDeviceID/withDeviceID.ino
@@ -22,8 +22,8 @@
 const char *ssid = "";
 const char *password = "";
 
-// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
-esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>, <allow insecure https>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false, false);
 
 void setup()
 {

--- a/examples/withDeviceID/withDeviceID.ino
+++ b/examples/withDeviceID/withDeviceID.ino
@@ -16,13 +16,14 @@
 
 #include <esp32fota.h>
 #include <WiFi.h>
+#include <SPIFFS.h>
 
 // Change to your WiFi credentials
 const char *ssid = "";
 const char *password = "";
 
-// esp32fota esp32fota("<Type of Firme for this device>", <this version>, <validate signature>);
-esp32FOTA FOTA("esp32-fota-http", 1, false);
+// esp32FOTA esp32FOTA("<Type of Firmware for this device>", <this version>, <filesystem>, <validate signature>);
+esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
 
 void setup()
 {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32FOTA",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "keywords": "firmware, OTA, Over The Air Updates, ArduinoOTA",
   "description": "Allows for firmware to be updated from a webserver, the device can check for updates at any time. Uses a simple JSON file to outline if a new firmware is avaiable.",
   "examples": "examples/*/*.ino",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=esp32FOTA
-version=0.1.6
+version=1.0.0
 author=Chris Joyce
 maintainer=Chris Joyce <chris@joyce.id.au>
 sentence=A simple library for firmware OTA updates

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -29,8 +29,11 @@ class esp32FOTA
   using FS = fs::FS;
 
 public:
-  esp32FOTA(String firwmareType, int firwmareVersion, const fs::FS& fs, boolean validate = false, boolean allow_insecure_https = false  );
-  esp32FOTA(String firwmareType, String firmwareSemanticVersion, const fs::FS& fs, boolean validate, boolean allow_insecure_https );  
+  esp32FOTA(String firwmareType, int firwmareVersion, const fs::FS& fs, boolean validate, boolean allow_insecure_https);
+  esp32FOTA(String firwmareType, String firmwareSemanticVersion, const fs::FS& fs, boolean validate, boolean allow_insecure_https);
+
+  esp32FOTA(String firwmareType, int firwmareVersion, const fs::FS& fs, boolean validate, boolean allow_insecure_https, String url);
+  esp32FOTA(String firwmareType, String firmwareSemanticVersion, const fs::FS& fs, boolean validate, boolean allow_insecure_https, String url);  
   ~esp32FOTA();
   void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
   void forceUpdate(String firmwareURL, boolean validate );

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -8,7 +8,7 @@
    Author: Moritz Meintker <https://thinksilicon.de>
    Remarks: Re-written/removed a bunch of functions around HTTPS. The library is
             now URL-agnostic. This means if you provide an https://-URL it will
-            use the root_ca.pem (needs to be provided via SPIFFS) to verify the
+            use the root_ca.pem (needs to be provided via SPIFFS/LittleFS) to verify the
             server certificate and then download the ressource through an encrypted
             connection.
             Otherwise it will just use plain HTTP which will still offer to sign
@@ -19,13 +19,17 @@
 #define esp32fota_h
 
 #include <Arduino.h>
+#include <FS.h>
 #include "semver/semver.h"
 
 class esp32FOTA
 {
+  using File = fs::File;
+  using FS = fs::FS;
+
 public:
-  esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false, boolean allow_insecure_https = false );
-  esp32FOTA(String firwmareType, String firmwareSemanticVersion, boolean validate = false, boolean allow_insecure_https = false );
+  esp32FOTA(String firwmareType, int firwmareVersion, const fs::FS& fs, boolean validate = false, boolean allow_insecure_https = false  );
+  esp32FOTA(String firwmareType, String firmwareSemanticVersion, const fs::FS& fs, boolean validate, boolean allow_insecure_https );  
   ~esp32FOTA();
   void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
   void forceUpdate(String firmwareURL, boolean validate );
@@ -39,6 +43,7 @@ public:
   bool validate_sig( unsigned char *signature, uint32_t firmware_size );
 
 private:
+  FS _fs;
   String getDeviceID();
   String _firmwareType;
   semver_t _firmwareVersion = {0};

--- a/src/semver/semver.c
+++ b/src/semver/semver.c
@@ -499,7 +499,7 @@ semver_free (semver_t *x) {
  */
 
 static void
-concat_num (char * str, int x, char * sep) {
+concat_num (char * str, int x, const char * sep) {
   char buf[SLICE_SIZE] = {0};
   if (sep == NULL) sprintf(buf, "%d", x);
   else sprintf(buf, "%s%d", sep, x);
@@ -507,7 +507,7 @@ concat_num (char * str, int x, char * sep) {
 }
 
 static void
-concat_char (char * str, char * x, char * sep) {
+concat_char (char * str, char * x, const char * sep) {
   char buf[SLICE_SIZE] = {0};
   sprintf(buf, "%s%s", sep, x);
   strcat(str, buf);


### PR DESCRIPTION
This PR is a **breaking change to the library**, introducing a new filesystem variable in the `esp32FOTA` constructor. This is intended to be used similar to the following:

**Spiffs Example:**
```
#include <FS.h>
#include <SPIFFS.h>
#include <esp32fota.h>

esp32FOTA esp32FOTA("esp32-fota-http", 1, SPIFFS, false);
```

**LittleFS Example (Arduino Core 1):**
```
#include <FS.h>
#include <LITTLEFS.h>
#include <esp32fota.h>

esp32FOTA esp32FOTA("esp32-fota-http", 1, LITTLEFS, false);
```

Users can update their code to use this version of the library by simply inserting their filesystem after the version number (`SPIFFS` or `LIITTLEFS` in the above)


This filesystem variable allows for the user to pass in the actual filesystem that he/she is using rather than having it assumed that he/she is using SPIFFS. This format ensures that the user can use SPIFFS, LittleFS (Arduino Core 2), or LITTLEFS (Arduino Core 1) without additional changes, and also potentially enables the use of SD cards/FATfs if additional changes were made to allow selecting the storage location.

Unfortunately, the way that ESP32 implements the filesystem drivers mean that attempting to use an incompatible driver can result in the filesystem being wiped out. This change ensures that this will never occur by having the user select the filesystem rather than defaulting to SPIFFS.

This implementation follows the way that similar features are implemented in other core libraries which are filesystem-agnostic such as [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer).