### PR TITLE
Using LittleFS and improving `semver.c` to fix some compiler's warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ A simple library to add support for Over-The-Air (OTA) updates to your project.
 
 ## Features and Improvements added by Tuan_Karma (Anthony)
 
-- [ ] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
-- [ ] Code improvements to eliminate Compiler's warnings
+- [x] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
+- [x] Code improvements at `semver/semver.c` to eliminate the Compiler's warnings: e.g. `warning: passing argument 3 of 'concat_num' discards 'const' qualifier ...`
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ A simple library to add support for Over-The-Air (OTA) updates to your project.
 - [x] Semantic versioning support
 - [ ] Checking for update via bin headers [issue 15]
 
+## Features and Improvements added by Tuan_Karma (Anthony)
+
+- [x] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
+- [x] Code improvements at `semver/semver.c` to eliminate the Compiler's warnings: e.g. `warning: passing argument 3 of 'concat_num' discards 'const' qualifier ...`
+- ...
+
 ## How it works
 
 This library tries to access a JSON file hosted on a webserver, and reviews it to decide if a newer firmware has been published, if so it will download it and install it.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ A simple library to add support for Over-The-Air (OTA) updates to your project.
 - [x] Semantic versioning support
 - [ ] Checking for update via bin headers [issue 15]
 
-## Features and Improvements added by Tuan_Karma (Anthony)
-
-- [x] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
-- [x] Code improvements at `semver/semver.c` to eliminate the Compiler's warnings: e.g. `warning: passing argument 3 of 'concat_num' discards 'const' qualifier ...`
-
 ## How it works
 
 This library tries to access a JSON file hosted on a webserver, and reviews it to decide if a newer firmware has been published, if so it will download it and install it.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ A simple library to add support for Over-The-Air (OTA) updates to your project.
 - [x] Semantic versioning support
 - [ ] Checking for update via bin headers [issue 15]
 
+## Features and Improvements added by Tuan_Karma (Anthony)
+
+- [ ] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
+- [ ] Code improvements to eliminate Compiler's warnings
+
 ## How it works
 
 This library tries to access a JSON file hosted on a webserver, and reviews it to decide if a newer firmware has been published, if so it will download it and install it.

--- a/examples/HTTP/HTTPS.ino
+++ b/examples/HTTP/HTTPS.ino
@@ -6,7 +6,7 @@
    Setup:
    Step 1 : Set your WiFi (ssid & password)
    Step 2 : set esp32fota()
-   Step 3 : Provide SPIFFS filesystem with root_ca.pem of your webserver
+   Step 3 : Provide LittleFS filesystem with root_ca.pem of your webserver
    
    Upload:
    Step 1 : Menu > Sketch > Export Compiled Library. The bin file will be saved in the sketch folder (Menu > Sketch > Show Sketch folder)
@@ -20,7 +20,7 @@
 #include <WiFi.h>
 
 #include <FS.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <esp32fota.h>
 
 
@@ -51,8 +51,8 @@ void setup_wifi()
 
 void setup()
 {
-  // Provide spiffs with root_ca.pem to validate server certificate
-  SPIFFS.begin(true);
+  // Provide LittleFS with root_ca.pem to validate server certificate
+  LittleFS.begin(true);
   
   esp32FOTA.checkURL = "https://server/fota/fota.json";
   Serial.begin(115200);

--- a/examples/HTTP/HTTPS_without_root_cert.ino
+++ b/examples/HTTP/HTTPS_without_root_cert.ino
@@ -19,7 +19,7 @@
 #include <WiFi.h>
 
 #include <FS.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <esp32fota.h>
 
 

--- a/examples/HTTP/HTTP_signature_check.ino
+++ b/examples/HTTP/HTTP_signature_check.ino
@@ -17,7 +17,7 @@
 #include <WiFi.h>
 
 #include <FS.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 
 #include <esp32fota.h>
 
@@ -34,8 +34,8 @@ void setup_wifi()
   Serial.print("Connecting to ");
   Serial.println(ssid);
 
-  // Need to provide SPIFFS with rsa_key.pub inside.
-  SPIFFS.begin( true );
+  // Need to provide LittleFS with rsa_key.pub inside.
+  LittleFS.begin( true );
   
   WiFi.begin(ssid, password);
 

--- a/examples/headerFileKey/main.cpp
+++ b/examples/headerFileKey/main.cpp
@@ -1,0 +1,66 @@
+/*
+Date: 2022-08-24
+Author: Nguyen Anh Tuan <https://github.com/tuan-karma>
+Feature added: use the rsa_pub_key.h to embed the key into the fimrware. This feature helps:
+- Preventing someone with physical access to your esp32-board altering the rsa_pub_key in the SPI flash memory 
+hence compromising the next firmware update.
+- Being able to update the rsa_key for the next version of your firmware conveniently. 
+
+Usges:
+    + Gen the rsa_key.pub as raw format from openssl. 
+    + Copy and paste the raw content in rsa_key.pub into the space between a "Raw string literal" as seen above. 
+    + `R"~~~(<your_rsa_raw_text_here_without_any_extra_space_or_newline)~~~"` 
+    + Include the `...rsa_pub_key.h` only in your main.cpp code. And use the API as seen in this example.
+
+Local server using python:
+- `python -m http.server --help`
+
+*/
+
+#include <Arduino.h>
+#include <esp32fota.h>
+#include <WiFi.h>
+#include <LittleFS.h>
+#include "ota_rsa_pub_key.h"
+namespace
+{
+    const char *ssid = "VTCC";
+    const char *pass = "vtcc40pbc";
+    const char *current_version = "0.1.2";
+}
+
+esp32FOTA mOTA("m5stack_FOTA", current_version, rsa_pub_key, sizeof(rsa_pub_key), true);
+
+void setup_wifi()
+{
+    delay(10);
+    // LittleFS.begin(false);
+    
+    Serial.printf("Connecting to %s ", ssid);
+    WiFi.begin(ssid, pass);
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        delay(500);
+        Serial.print(".");
+    }
+    Serial.println("\nWF Connected!");
+}
+
+void setup()
+{
+    mOTA.checkURL = "http://10.130.0.141:8000/firmwares.json";
+    Serial.begin(115200);
+    Serial.println(current_version);
+    setup_wifi();
+}
+
+void loop()
+{
+    bool updateNeeded = mOTA.execHTTPcheck();
+    if (updateNeeded)
+    {
+        Serial.println("A newer firmware version was found --> update");
+        mOTA.execOTA_internal();
+    }
+    delay(2000);
+}

--- a/examples/headerFileKey/ota_rsa_pub_key.h
+++ b/examples/headerFileKey/ota_rsa_pub_key.h
@@ -1,0 +1,25 @@
+static const unsigned char rsa_pub_key[] = R"~~~(-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA04D07cMpLUVQCLeNCUB0
+IcKhKUG35JExPwqo58w/BviOueU6ibOROxf63kI+yljFg8B2aV1lB5Fi8WeftF6s
+dex+Y4t5i/vBC2RlIcO9cNs1yxCVKkpTqMv4j2M9gdjyM5PAsk8VmIG/siPNiI56
+MMO+1aSF6aQMaUW1kvIiMQM7d7NoqSuP+DHjYWCKrU2T3eMn/zxa9jIohyQcSfdV
+uPJjZuvgmST7qHAk/7YR6lcrbB25+jqrRReloZFEvH0iSMHB+ruAihsVIrLNK6iE
+kBF6UN5etYBez210Huouyneb2V7WzbLvBTf3E+fmTMyrZxPL4/DWfz0hhPkWmGpI
+j1xLqknr6OTSEQ3f5YWU7byGEvs5fqaMokqR73gNjP5WzTBAFWaiH1PtaezasUtr
+WZ7GegTepRvXta+A3XJVnwmhZbxB7uJsRkKxUQsqEMC+RDqH9RFalGZKaP2wrIce
+TYTMhbKL6Gg/w7M514yqonIfoul2iKkN3wtlDxU7NL4bAbc6NRidgvOOLVKsNN2p
+Oib3h1xgJfpW3y6kODCA71ZK47DkhS/eSR3vXGMJfx2uaas6lg5KiIo0KlHxzzMj
+HqoLBoiNUfXqJ6kbAwo2o8/K/pQy06pjCCAKaozJPJ3jQl1Js22SsQKFo45UsQkD
+RsvhLheT146a+Cba80NApvsCAwEAAQ==
+-----END PUBLIC KEY-----
+)~~~";
+
+/*
+- This file is for conveniently storing rsa_public_key to use/embed in the fimrware.
+- You should only include this file once and only-once in the main.cpp source file.
+- ... Then use the rsa_pub_key as a global char pointer to the raw_rsa_pub_key_c_str.
+- Usage:
+    + Gen the rsa_key.pub as raw format from openssl. 
+    + Copy and paste the raw content in rsa_key.pub into the space between a "Raw string literal" as seen above. 
+    + `R"~~~(<your_rsa_raw_text_here_without_any_extra_space_or_newline)~~~"` 
+*/

--- a/library.properties
+++ b/library.properties
@@ -1,11 +1,11 @@
-name=esp32FOTA
-version=0.1.6
+name=esp32FOTA_T
+version=0.1.0
 author=Chris Joyce
-maintainer=Chris Joyce <chris@joyce.id.au>
-sentence=A simple library for firmware OTA updates
+maintainer=Anthony <anhtuan1 at gmail dot com>
+sentence=A fork of Chris Joye's esp32FOTA library. Some improvements by Nguyen Anh Tuan (anhtuanb1@gmail.com)
 paragraph=Allows for firmware to be updated from a webserver, the device can check for updates at any time. Uses a simple JSON file to outline if a new firmware is avaiable.
 category=Communication
-url=https://github.com/chrisjoyce911/esp32FOTA
+url=https://github.com/tuan-karma/esp32FOTA.git
 architectures=esp32,espressif32
 includes=esp32fota.h
 depends=ArduinoJson

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -21,7 +21,6 @@
 #include <HTTPClient.h>
 #include <Update.h>
 #include "ArduinoJson.h"
-#include <FS.h>
 #include <LittleFS.h>
 
 

--- a/src/esp32fota.cpp
+++ b/src/esp32fota.cpp
@@ -8,7 +8,7 @@
    Author: Moritz Meintker <https://thinksilicon.de>
    Remarks: Re-written/removed a bunch of functions around HTTPS. The library is
             now URL-agnostic. This means if you provide an https://-URL it will
-            use the root_ca.pem (needs to be provided via SPIFFS) to verify the
+            use the root_ca.pem (needs to be provided via LittleFS) to verify the
             server certificate and then download the ressource through an encrypted
             connection unless you set the allow_insecure_https option.
             Otherwise it will just use plain HTTP which will still offer to sign
@@ -22,7 +22,7 @@
 #include <Update.h>
 #include "ArduinoJson.h"
 #include <FS.h>
-#include <SPIFFS.h>
+#include <LittleFS.h>
 
 
 #include "mbedtls/pk.h"
@@ -79,7 +79,7 @@ bool esp32FOTA::validate_sig( unsigned char *signature, uint32_t firmware_size )
     mbedtls_md_context_t rsa;
 
     { // Open RSA public key:
-        File public_key_file = SPIFFS.open( "/rsa_key.pub" );
+        File public_key_file = LittleFS.open( "/rsa_key.pub" );
         if( !public_key_file ) {
             log_e( "Failed to open rsa_key.pub for reading" );
             return false;
@@ -190,7 +190,7 @@ void esp32FOTA::execOTA()
             // and provide the root_ca.pem
             log_i( "Loading root_ca.pem" );
             //WiFiClientSecure client;
-            File root_ca_file = SPIFFS.open( "/root_ca.pem" );
+            File root_ca_file = LittleFS.open( "/root_ca.pem" );
             if( !root_ca_file ) {
                 log_e( "Could not open root_ca.pem" );
                 return;
@@ -402,7 +402,7 @@ bool esp32FOTA::execHTTPcheck()
         if (!_allow_insecure_https) {
             // If the checkURL is https load the root-CA and connect with that
             log_i( "Loading root_ca.pem" );
-            File root_ca_file = SPIFFS.open( "/root_ca.pem" );
+            File root_ca_file = LittleFS.open( "/root_ca.pem" );
             if( !root_ca_file ) {
                 log_e( "Could not open root_ca.pem" );
                 return false;

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -13,6 +13,12 @@
             connection.
             Otherwise it will just use plain HTTP which will still offer to sign
             your firmware image.
+    Date: 2022-08-24
+    Author: Nguyen Anh Tuan <https://github.com/tuan-karma>
+    Feature added: use the rsa_pub_key.h to embed the key into the fimrware. This feature helps:
+    - Preventing someone with physical access to your esp32-board altering the rsa_pub_key in the SPI flash memory
+    hence compromising the next firmware update.
+    - Being able to update the rsa_key for the next version of your firmware conveniently.
 */
 
 #ifndef esp32fota_h
@@ -25,19 +31,21 @@
 class esp32FOTA
 {
 public:
-  esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false, boolean allow_insecure_https = false );
-  esp32FOTA(String firwmareType, String firmwareSemanticVersion, boolean validate = false, boolean allow_insecure_https = false );
+  esp32FOTA(String firwmareType, int firwmareVersion, boolean validate = false, boolean allow_insecure_https = false);
+  esp32FOTA(String firwmareType, String firmwareSemanticVersion, boolean validate = false, boolean allow_insecure_https = false);
+  esp32FOTA(String firwmareType, String firmwareSemanticVersion, const unsigned char *public_key, size_t public_key_length, boolean allow_insecure_https = true);
   ~esp32FOTA();
-  void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate );
-  void forceUpdate(String firmwareURL, boolean validate );
-  void forceUpdate(boolean validate );
+  void forceUpdate(String firmwareHost, uint16_t firmwarePort, String firmwarePath, boolean validate);
+  void forceUpdate(String firmwareURL, boolean validate);
+  void forceUpdate(boolean validate);
   void execOTA();
+  void execOTA_internal();
   bool execHTTPcheck();
   int getPayloadVersion();
-  void getPayloadVersion(char * version_string);
+  void getPayloadVersion(char *version_string);
   bool useDeviceID;
   String checkURL;
-  bool validate_sig( unsigned char *signature, uint32_t firmware_size );
+  bool validate_sig(unsigned char *signature, uint32_t firmware_size);
 
 private:
   String getDeviceID();
@@ -46,9 +54,11 @@ private:
   semver_t _payloadVersion = {0};
   String _firmwareUrl;
   boolean _check_sig;
+  const unsigned char *_public_key = nullptr;
+  size_t _public_key_length = 0;
   boolean _allow_insecure_https;
   bool checkJSONManifest(JsonVariant JSONDocument);
-
+  bool validate_sig_internal(const unsigned char *signature, const uint32_t firmware_size);
 };
 
 #endif

--- a/src/esp32fota.h
+++ b/src/esp32fota.h
@@ -8,7 +8,7 @@
    Author: Moritz Meintker <https://thinksilicon.de>
    Remarks: Re-written/removed a bunch of functions around HTTPS. The library is
             now URL-agnostic. This means if you provide an https://-URL it will
-            use the root_ca.pem (needs to be provided via SPIFFS) to verify the
+            use the root_ca.pem (needs to be provided via LittleFS) to verify the
             server certificate and then download the ressource through an encrypted
             connection.
             Otherwise it will just use plain HTTP which will still offer to sign

--- a/src/semver/semver.c
+++ b/src/semver/semver.c
@@ -499,7 +499,7 @@ semver_free (semver_t *x) {
  */
 
 static void
-concat_num (char * str, int x, char * sep) {
+concat_num (char * str, int x, const char * sep) {
   char buf[SLICE_SIZE] = {0};
   if (sep == NULL) sprintf(buf, "%d", x);
   else sprintf(buf, "%s%d", sep, x);
@@ -507,7 +507,7 @@ concat_num (char * str, int x, char * sep) {
 }
 
 static void
-concat_char (char * str, char * x, char * sep) {
+concat_char (char * str, char * x, const char * sep) {
   char buf[SLICE_SIZE] = {0};
   sprintf(buf, "%s%s", sep, x);
   strcat(str, buf);


### PR DESCRIPTION
Dear chrisjoyce911: Thank you for your useful esp32FOTA library. I would like to added some minor improvements and bug fixes as following:

- [x] Using LitleFS instead of (deprecated) [SPIFFS](https://arduino-esp8266.readthedocs.io/en/latest/filesystem.html#spiffs-and-littlefs)
- [x] Code improvements at `semver/semver.c` to eliminate the Compiler's warnings: e.g. `warning: passing argument 3 of 'concat_num' discards 'const' qualifier ...`

Know limitations:
- No limitations added

Tested:
- On an ESP32 dev board.

I hope and believe that the above improvements is useful for future users of this library and that change not break any API of your library. Thank you for you time!