### PR TITLE
Force SPIFFS Update and custom key length

### DIFF
--- a/src/esp32FOTA.cpp
+++ b/src/esp32FOTA.cpp
@@ -851,6 +851,15 @@ void esp32FOTA::forceUpdate(const char* firmwareURL, bool validate )
     execOTA();
 }
 
+// Force a firmware update regardless on current version
+void esp32FOTA::forceUpdateSPIFFS(const char* firmwareURL, bool validate )
+{
+    _firmwareUrl = firmwareURL;
+    _flashFileSystemUrl = firmwareURL;
+    _cfg.check_sig = validate;
+    execOTA();
+}
+
 
 void esp32FOTA::forceUpdate(const char* firmwareHost, uint16_t firmwarePort, const char*  firmwarePath, bool validate )
 {

--- a/src/esp32FOTA.hpp
+++ b/src/esp32FOTA.hpp
@@ -147,7 +147,7 @@ extern "C" {
   #define F_writeStream() F_Update.writeStream(*_stream);
 #endif
 
-
+#define FW_SIGNATURE_LENGTH     512
 
 struct SemverClass
 {
@@ -211,6 +211,7 @@ struct FOTAConfig_t
   bool         use_device_id { false };
   CryptoAsset* root_ca { nullptr };
   CryptoAsset* pub_key { nullptr };
+  size_t       signature_len {FW_SIGNATURE_LENGTH};
   FOTAConfig_t() = default;
 };
 
@@ -266,6 +267,9 @@ public:
 
   // use this to set "Authorization: Basic" or other specific headers to be sent with the queries
   void setExtraHTTPHeader( String name, String value ) { extraHTTPHeaders[name] = value; }
+
+  // set the signature len
+  void setSignatureLen( size_t len );
 
   // /!\ Only use this to change filesystem for **default** RootCA and PubKey paths.
   // Otherwise use setPubKey() and setRootCA()

--- a/src/esp32FOTA.hpp
+++ b/src/esp32FOTA.hpp
@@ -246,6 +246,8 @@ public:
   void forceUpdate(const char* firmwareURL, bool validate );
   void forceUpdate(bool validate );
 
+  void forceUpdateSPIFFS(const char* firmwareURL, bool validate );
+
   void handle();
 
   bool execOTA();

--- a/src/esp32FOTA.hpp
+++ b/src/esp32FOTA.hpp
@@ -243,15 +243,16 @@ public:
   template <typename T> void setPubKey( T* asset ) { _cfg.pub_key = (CryptoAsset*)asset; _cfg.check_sig = true; }
   template <typename T> void setRootCA( T* asset ) { _cfg.root_ca = (CryptoAsset*)asset; _cfg.unsafe = false; }
 
-  void forceUpdate(const char* firmwareHost, uint16_t firmwarePort, const char* firmwarePath, bool validate );
-  void forceUpdate(const char* firmwareURL, bool validate );
-  void forceUpdate(bool validate );
+  bool forceUpdate(const char* firmwareHost, uint16_t firmwarePort, const char* firmwarePath, bool validate );
+  bool forceUpdate(const char* firmwareURL, bool validate );
+  bool forceUpdate(bool validate );
 
-  void forceUpdateSPIFFS(const char* firmwareURL, bool validate );
+  bool forceUpdateSPIFFS(const char* firmwareURL, bool validate );
 
   void handle();
 
   bool execOTA();
+  bool execSPIFFSOTA();
   bool execOTA( int partition, bool restart_after = true );
   bool execHTTPcheck();
 


### PR DESCRIPTION
I've added the function forceUpdateSPIFFS with the same logic of forceUpdate to have the possibility to update the SPIFFS without json from a custum url, i've added a new function for the OTA execution because with execOTA after the spiffs update the code was trying also to download a new firmware.
I've also added the length of the signature key to use the same key that is used in some esp8266 system that have a key length limitation. To to that i've added a member to store the key lenght that at default is 512 as before. The signature variable now is dynamic allocated to manage the different size.
I've made and test this code to force the update of a esp32 from a URL that is coming from mqtt.