### PR TITLE
Fix type mismatch in error reporting

### DIFF
--- a/src/esp32FOTA.cpp
+++ b/src/esp32FOTA.cpp
@@ -564,7 +564,7 @@ bool esp32FOTA::execOTA( int partition, bool restart_after )
     }
 
     if (!F_UpdateEnd()) {
-        log_e("An Update Error Occurred. Error #: %s", F_Update.getError());
+        log_e("An Update Error Occurred. Error #: %d", F_Update.getError());
         return false;
     }
 


### PR DESCRIPTION
There is a type mismatch in the reporting of an update failure [here](https://github.com/chrisjoyce911/esp32FOTA/blob/2bbc9cb3430440946995745be7d124505b557a86/src/esp32FOTA.cpp#L567)

getError() returns an uint8
```c
    uint8_t getError(){ return _error; }
```
but it's expecting a char*
```c
        log_e("An Update Error Occurred. Error #: %s", F_Update.getError());
```
If called, this crashes the esp32 as printf would try to access the uint8 as address for a char[].

This PR is to replace the line of log to:
```c
        log_e("An Update Error Occurred. Error #: %d", F_Update.getError());
```

Thanks
