### PR TITLE
prevent ESP from restarting if signature check fails, so errors can b…

### DIFF
--- a/src/esp32FOTA.cpp
+++ b/src/esp32FOTA.cpp
@@ -638,10 +638,6 @@ bool esp32FOTA::execOTA( int partition, bool restart_after )
             if( onUpdateCheckFail ) onUpdateCheckFail( partition, CHECK_SIG_ERROR_VALIDATION_FAILED );
 
             log_e("Signature check failed!");
-            if( restart_after ) {
-                log_w("Rebooting.");
-                ESP.restart();
-            }
             return false;
         } else {
             delete[] signature;


### PR DESCRIPTION
Thx for these great library!

In execOTA(), line 486, you promise:
`    // handle the application partition and restart on success`
`    bool ret = execOTA( U_FLASH, true );
`

...but also when there is a failure, the device is restarted. This prevents informing the user what happend ("verification failed").

I hope you will process this PR so I can remove my fork :-) 