### PR TITLE
feat: Added setting for http reuse (keep-alive)

### DIFF
--- a/src/esp32FOTA.cpp
+++ b/src/esp32FOTA.cpp
@@ -189,6 +189,7 @@ void esp32FOTA::setConfig( FOTAConfig_t cfg )
     _cfg.root_ca       = cfg.root_ca;
     _cfg.pub_key       = cfg.pub_key;
     _cfg.signature_len = cfg.signature_len;
+    _cfg.allow_reuse   = cfg.allow_reuse;
 }
 
 
@@ -206,7 +207,8 @@ void esp32FOTA::printConfig( FOTAConfig_t *cfg )
     cfg->use_device_id ?"true":"false",
     cfg->root_ca ?"true":"false",
     cfg->pub_key ?"true":"false",
-    cfg->signature_len
+    cfg->signature_len,
+    cfg->allow_reuse
   );
 }
 
@@ -364,7 +366,8 @@ bool esp32FOTA::setupHTTP( const char* url )
 {
     const char* rootcastr = nullptr;
     _http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-
+    _http.setReuse(_cfg.allow_reuse);
+    
     log_i("Connecting to: %s", url );
     if( String(url).startsWith("https") ) {
         if (!_cfg.unsafe) {

--- a/src/esp32FOTA.hpp
+++ b/src/esp32FOTA.hpp
@@ -220,6 +220,7 @@ struct FOTAConfig_t
   CryptoAsset* root_ca { nullptr };
   CryptoAsset* pub_key { nullptr };
   size_t       signature_len {FW_SIGNATURE_LENGTH};
+  bool         allow_reuse { true };
   FOTAConfig_t() = default;
 };
 


### PR DESCRIPTION
This PR adds a configuration option to set the "http reuse" aka keep-alive.

```
cfg.allow_reuse = false;  // disables keep alive and kills connection when done
```

Some time after `framework-arduinoespressif32 @ 3.20003.220626 (2.0.3)` the heap usage drastically increased for https calls. If one has a project that makes https calls as well as the esp32FOTA library the heap can get to a point where one runs out of memory.

Since OTAs are generally not something that gets done a lot it should not consume too much of the heap especially if there is no update.

This option reduces the used heap by around `40k` after OTA check call is done. 

I wasn't sure if I should add this as a function or in the configuration. Please let me know if you would like any changes done.

