### PR TITLE
fix url assembly in forceUpdate

### DIFF
--- a/src/esp32FOTA.cpp
+++ b/src/esp32FOTA.cpp
@@ -908,6 +908,7 @@ bool esp32FOTA::forceUpdate(const char* firmwareHost, uint16_t firmwarePort, con
 {
     static String firmwareURL("http");
     if ( firmwarePort == 443 || firmwarePort == 4433 ) firmwareURL += "s";
+    firmwareURL += "://";
     firmwareURL += String(firmwareHost);
     firmwareURL += ":";
     firmwareURL += String(firmwarePort);


### PR DESCRIPTION
in method  
```
bool esp32FOTA::forceUpdate(const char* firmwareHost, uint16_t firmwarePort, const char*  firmwarePath, bool validate )
```
url assembly was missing a '://' between protocol and host part.
```
forceUpdate("update.myhost.com", 80, "/firmware.bin", true)  
```
resulted in 
```
"httpupdate.myhost.com:80/firmware.bin"
```
instead of
```
"http://update.myhost.com:80/firmware.bin"
```
