### PR TITLE
docs: clarify URL field behavior in JSON manifest format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,46 @@ Version information can be either a single number or a semantic version string. 
 }
 ```
 
+### ⚠️ Important: URL Field Behavior
+
+**When using the `url` field in your manifest, all other URL-related fields will be ignored.** This includes:
+- `host`, `port`, `bin` fields
+- Filesystem fields: `spiffs`, `littlefs`, `fatfs`
+
+```json
+// ❌ This will NOT work - littlefs will be ignored because 'url' is present
+{
+  "type": "esp32-fota-http",
+  "version": "1.0.0",
+  "url": "https://example.com/firmware.bin",
+  "littlefs": "https://example.com/filesystem.bin"  // IGNORED!
+}
+
+// ✅ Use this format for firmware + filesystem updates
+{
+  "type": "esp32-fota-http",
+  "version": "1.0.0",
+  "host": "example.com",
+  "port": 443,
+  "bin": "/firmware.bin",
+  "littlefs": "/filesystem.bin"
+}
+
+// ✅ Or this format for firmware-only updates
+{
+  "type": "esp32-fota-http",
+  "version": "1.0.0",
+  "url": "https://example.com/firmware.bin"
+}
+```
+
+**Manifest Format Options:**
+
+1. **Complete URL (firmware only)**: Use `url` field - filesystem updates not supported
+2. **Component-based URLs (firmware + filesystem)**: Use `host`, `port`, `bin`, and optional `spiffs`/`littlefs`/`fatfs` fields
+
+You cannot mix these approaches in a single manifest.
+
 A single JSON file can provide information on multiple firmware types by combining them together into an array. When this is loaded, the firmware manifest with a type matching the one passed to the esp32FOTA constructor will be selected:
 
 ```json


### PR DESCRIPTION
## Scope of Change

This PR adds important documentation clarification to the README.md file regarding JSON manifest format behavior. Specifically, it adds a warning section that explains how the `url` field interacts with other URL-related fields.

**What the change does:**
- Adds a new warning section "⚠️ Important: URL Field Behavior" to the README.md
- Clarifies that when `url` field is present, all other URL-related fields are ignored
- Provides clear examples of what works vs. what doesn't work
- Explains the two supported manifest format approaches

**Parts of code modified:**
- README.md only (documentation change, no code modifications)

## Background

Users were experiencing confusion when trying to use both `url` and filesystem fields (`littlefs`, `spiffs`, `fatfs`) in the same manifest, expecting both to work. The current library behavior (as implemented in `checkJSONManifest()`) ignores all other URL-related fields when `url` is present, but this wasn't documented.

## Known Limitations

- This is a documentation-only change
- No functional code changes are included
- The underlying library behavior remains unchanged (by design)

## Testing

- Verified the markdown formatting renders correctly
- Confirmed the examples accurately reflect the current library behavior as implemented in the source code
- No functional testing required as this is documentation only

This change helps prevent user confusion and makes the manifest format requirements explicit, improving the developer experience when working with filesystem updates.