### PR TITLE
Add Optional Support for ESP-IDF Bundled CA Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,11 @@ $ gzip -c esp32-fota-http-2.bin > esp32-fota-http-2.bin.gz
 
 Arduino 3.x now supports bundled root certificates, which means 99% of sites (including github.com) will work over https and you don't need to maintain a custom certificate on your firmware.
 
-To enable this functionality, simply call ```esp32FOTA.useBundledCerts();``` during your setup.
+To enable this functionality, simply call this during your setup:
+
+```C++
+esp32FOTA.useBundledCerts();
+``` 
 
 If you are using Platformio / PIOArduino, the certificates are not automatically bundled and you will need to download them from [CURL](https://curl.se/docs/caextract.html).
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,22 @@ $ gzip -c esp32-fota-http-2.bin > esp32-fota-http-2.bin.gz
 
 ### Root Certificates
 
+#### Certificate Bundles
+
+Arduino 3.x now supports bundled root certificates, which means 99% of sites (including github.com) will work over https and you don't need to maintain a custom certificate on your firmware.
+
+To enable this functionality, simply call ```esp32FOTA.useBundledCerts();``` during your setup.
+
+If you are using Platformio / PIOArduino, the certificates are not automatically bundled and you will need to download them from [CURL](https://curl.se/docs/caextract.html).
+
+Save that file to your project root directory and then add this line to your platformio.ini:
+
+```board_build.embed_txtfiles=ca_cert_bundle```
+
+Make sure it is named exactly ca_cert_bundle with no extension and located in the top level of your project.
+
+#### Custom Certificates
+
 Certificates and signatures can be stored in different places: any fs::FS filesystem or progmem as const char*.
 
 Filesystems:

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32FOTA",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "keywords": "firmware, OTA, Over The Air Updates, ArduinoOTA",
   "description": "Allows for firmware to be updated from a webserver, the device can check for updates at any time. Uses a simple JSON file to outline if a new firmware is avaiable.",
   "examples": "examples/*/*.ino",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=esp32FOTA
-version=0.2.9
+version=0.3.0
 author=Chris Joyce
 maintainer=Chris Joyce <chris@joyce.id.au>
 sentence=A simple library for firmware OTA updates

--- a/src/esp32FOTA.hpp
+++ b/src/esp32FOTA.hpp
@@ -222,6 +222,7 @@ struct FOTAConfig_t
   size_t       signature_len {FW_SIGNATURE_LENGTH};
   bool         allow_reuse { true };
   bool         use_http10 { false }; // Use HTTP 1.0 (WARNING: setting to 'true' disables chunked transfers)
+  bool         use_bundled_certs { false };   // use built-in ESP-IDF CA bundle
   FOTAConfig_t() = default;
 };
 
@@ -287,6 +288,10 @@ public:
   void setCertFileSystem( fs::FS *cert_filesystem = nullptr );
 
   // this is passed to Update.onProgress()
+
+  // enable bundled CA certificates
+  void useBundledCerts(bool enable = true);
+
   typedef std::function<void(size_t,size_t)> ProgressCallback_cb; // size_t progress, size_t size
   void setProgressCb(ProgressCallback_cb fn) { onOTAProgress = fn; } // callback setter
 


### PR DESCRIPTION
This PR adds **optional support for using the ESP-IDF CA certificate bundle** when running on Arduino-ESP32 3.x (ESP-IDF 5.x).

## ✅ New Feature: Bundled Certificate Support

A new configuration field enables usage of the built-in CA bundle:

```cpp
esp32FOTA.useBundledCerts();
```
or
```cpp
cfg.use_bundled_certs = true;
```

When enabled:

- esp32FOTA attempts to load the ESP-IDF CA bundle via `setCACertBundle()`
- A weak-symbol check detects whether the bundle is actually linked
- If present, HTTPS requests use the full CA bundle
- If not present, esp32FOTA safely falls back to the existing TLS behavior

## ✅ Fully Backwards Compatible

- No changes to existing behavior unless the new option is explicitly enabled  
- Existing `root_ca` and `unsafe` modes continue to function normally  
- Compatible with both Arduino-ESP32 **2.x** and **3.x**  
- Compatible with **Arduino IDE** and **PlatformIO**  
- No build-time dependency on the CA bundle unless the user links it

## ✅ Runtime-Safe Detection

Weak symbol declarations prevent build failures when the CA bundle is not available.  
If the symbols are missing, esp32FOTA logs a message and falls back gracefully.

## Summary

This PR introduces a secure, modern HTTPS configuration path using the ESP-IDF root certificate store, without breaking existing setups or requiring code changes for current users.