### PR TITLE
Fix for projects that mix arduino and IDF frameworks

### DIFF
--- a/src/esp32FOTA.cpp
+++ b/src/esp32FOTA.cpp
@@ -541,7 +541,7 @@ bool esp32FOTA::execOTA()
 // OTA Logic
 bool esp32FOTA::execSPIFFSOTA()
 {
-	bool ret;
+	bool ret = false;
     setupStream();
 
     if( !_flashFileSystemUrl.isEmpty() ) { // a data partition was specified in the json manifest, handle the spiffs partition first


### PR DESCRIPTION
## Summary

This PR fix the next issue, that only happen in projects that mix Arduino and IDF frameworks.

```
esp32FOTA.cpp:559:12: error: 'ret' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     return ret;
            ^~~
```
